### PR TITLE
Feature/canvas oauth library

### DIFF
--- a/account_courses/urls.py
+++ b/account_courses/urls.py
@@ -1,5 +1,4 @@
 from django.conf.urls import url
-# from django.contrib import admin
 
 from account_courses import views as ac_views
 

--- a/account_courses/views.py
+++ b/account_courses/views.py
@@ -6,10 +6,8 @@ from django.http import HttpResponse
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.csrf import csrf_exempt
 from canvas_oauth.oauth import get_oauth_token
-from canvas_oauth.exceptions import InvalidTokenError
 
 from canvas_sdk.methods import accounts
-from canvas_sdk.exceptions import InvalidOAuthTokenError
 from canvas_sdk import RequestContext, client
 
 import logging
@@ -68,16 +66,11 @@ def main(request):
     if term_id and term_id != '' and term_id != 'all':
         term_id = 'sis_term_id:%s' % term_id
 
-    try:
-        if request.GET.get('page_link'):
-            api_response = client.get(rc, request.GET.get('page_link'))
-        else:
-
-            logger.debug('searching for "%s" and term "%s"' % (search_term, term_id))
-            api_response = accounts.list_active_courses_in_account(rc, account_id, search_term=search_term, enrollment_term_id=term_id, published=published, per_page=12)
-    except InvalidOAuthTokenError as ite:
-        logger.info("Caught an invalid token error from the SDK: %s", str(ite))
-        raise InvalidTokenError(str(ite))
+    if request.GET.get('page_link'):
+        api_response = client.get(rc, request.GET.get('page_link'))
+    else:
+        logger.debug('searching for "%s" and term "%s"' % (search_term, term_id))
+        api_response = accounts.list_active_courses_in_account(rc, account_id, search_term=search_term, enrollment_term_id=term_id, published=published, per_page=12)
 
     logger.debug(api_response.text)
     account_courses = api_response.json()

--- a/account_courses/views.py
+++ b/account_courses/views.py
@@ -1,23 +1,18 @@
-from django.shortcuts import render, render_to_response, redirect
+from django.shortcuts import render, redirect
 from django.views.decorators.http import require_http_methods
 from django.core.urlresolvers import reverse
 from ims_lti_py.tool_config import ToolConfig
 from django.http import HttpResponse
-from django.core.exceptions import ObjectDoesNotExist
-from django import template
-from ims_lti_py.tool_provider import DjangoToolProvider
-from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.csrf import csrf_exempt
-from icommons_common.models import CanvasOauthToken
+from canvas_oauth.oauth import get_oauth_token
+from canvas_oauth.exceptions import InvalidTokenError
 
 from canvas_sdk.methods import accounts
-from canvas_sdk import RequestContext
-from canvas_sdk import client
+from canvas_sdk.exceptions import InvalidOAuthTokenError
+from canvas_sdk import RequestContext, client
 
-from time import time
 import logging
-import requests
 import urllib
 
 logger = logging.getLogger(__name__)
@@ -37,138 +32,53 @@ TERMS = {
 
 # Create your views here.
 
+
 @require_http_methods(['GET'])
 def index(request):
     logger.info("request to index.")
     return render(request, 'account_courses/index.html')
 
+
 @login_required
-@require_http_methods(['POST'])
 @csrf_exempt
+@require_http_methods(['POST'])
 def lti_launch(request):
     if request.user.is_authenticated():
-
-
-
-        if request.session.get('canvas_api_token'):
-            # we have a token, so redirect the user to the main view
-            logger.debug("redirect user to the report page")
-            return redirect('ac:main')
-
-        user_tokens = CanvasOauthToken.objects.filter(user_id=request.user.username)
-        if user_tokens:
-            user_token = user_tokens[0]
-            request.session['canvas_api_token'] = user_token.token
-            # we have a token, so redirect the user to the main view
-            logger.debug("found token in database; redirect user to the report page")
-            return redirect('ac:main')
-
-        else:
-            # we need to send the user to Canvas to authorize this app and get a token
-            logger.debug("session doesn't have a canvas_api_token; redirecting user to OAuth workflow")
-            oauth_initial_state = '21345'
-            request.session['oauth_initial_state'] = urllib.quote_plus(oauth_initial_state)  # make this some random value
-            oauth_client_id = settings.REPORT_TOOLS['canvas_client_id']
-
-            if request.is_secure():
-                host = 'https://' + request.get_host()
-            else:
-                host = 'http://' + request.get_host()
-
-            url = host + reverse('oauth_complete')
-
-            redirect_uri = urllib.quote_plus(url)
-
-            oauth_redir_url = 'https://%s/login/oauth2/auth?client_id=%s&response_type=code&redirect_uri=%s&state=%s' % \
-                (request.session['LTI_LAUNCH'].get('custom_canvas_api_domain'), oauth_client_id, redirect_uri, oauth_initial_state)
-
-            logger.debug('No oauth2 token - redirect the user to Canvas to get one: %s' % oauth_redir_url)
-            return redirect(oauth_redir_url)
-
+        return redirect('ac:main')
     else:
         return render(request, 'account_courses/error.html', {'message': 'Error: user is not authenticated!'}) 
 
-
-@require_http_methods(['GET'])
-def oauth_complete(request):
-
-    # check for an error first
-    if request.GET.get('error'):
-        return render(request, 'account_courses/error.html', {'message': 'OAuth error: %s' % request.GET['error']})
-
-    else:
-        # get the code and the state
-        oauth_code = request.GET.get('code')
-        oauth_state = request.GET.get('state')
-
-        # check to make sure the state value matches the one that we put into the session 
-        logger.debug('oauth_initial_state is %s' % request.session.get('oauth_initial_state'))
-        logger.debug('oauth workflow state is %s' % oauth_state)
-
-        if oauth_state != request.session.get('oauth_initial_state'):
-            return render(request, 'account_courses/error.html', {'message': 'OAuth state mismatch.'})
-        else:
-            logger.debug('User granted the tool access to the API key; now fetch the key from Canvas')
-
-        # use the code to fetch the actual token
-        # generate a post request to /login/oauth2/token
-        oauth_token_url = 'https://%s/login/oauth2/token' % request.session['LTI_LAUNCH'].get('custom_canvas_api_domain')
-        logger.debug('Fetch key using this URL: %s' % oauth_token_url)
-        post_params = {
-            'client_id': settings.REPORT_TOOLS['canvas_client_id'],
-            'redirect_uri': reverse('oauth_complete'),
-            'client_secret': settings.REPORT_TOOLS['canvas_client_secret'],
-            'code': oauth_code,
-        }
-        r = requests.post(oauth_token_url, post_params)
-
-        if r.status_code == 200:
-            response_data = r.json()
-            canvas_api_token = response_data['access_token']
-            user_token = CanvasOauthToken(user_id=request.user.username, token=canvas_api_token)
-            user_token.save()
-            request.session['canvas_api_token'] = canvas_api_token
-            return redirect('ac:main')
-
-        else:
-            return render(request, 'account_courses/error.html', {'message': 'failed to get the token: %s' % r.text})
 
 @login_required
 @require_http_methods(['GET'])
 def main(request):
 
     # the current account ID is in custom_canvas_account_id
+    canvas_api_token = get_oauth_token(request)
     account_id = request.session['LTI_LAUNCH'].get('custom_canvas_account_id')
     account_name = request.session['LTI_LAUNCH'].get('custom_canvas_account_id')
 
-    canvas_api_token = request.session.get('canvas_api_token')
     canvas_api_url = 'https://%s/api' % request.session['LTI_LAUNCH'].get('custom_canvas_api_domain')
     rc = RequestContext(canvas_api_token, canvas_api_url, per_page=15)
 
-    search_term = None
-    term_id = None
-    published = None
-    if request.GET.get('search_term'):
-        if request.GET.get('search_term') == '':
-            search_term = ''
+    search_term = request.GET.get('search_term')
+    term_id = request.GET.get('term_id')
+    published = request.GET.get('published')
+
+    if term_id and term_id != '' and term_id != 'all':
+        term_id = 'sis_term_id:%s' % term_id
+
+    try:
+        if request.GET.get('page_link'):
+            api_response = client.get(rc, request.GET.get('page_link'))
         else:
-            search_term = request.GET.get('search_term')
 
-    if request.GET.get('term_id'):
-        if request.GET.get('term_id') != '' and request.GET.get('term_id') != 'all':
-            term_id = 'sis_term_id:%s' % request.GET.get('term_id')
+            logger.debug('searching for "%s" and term "%s"' % (search_term, term_id))
+            api_response = accounts.list_active_courses_in_account(rc, account_id, search_term=search_term, enrollment_term_id=term_id, published=published, per_page=12)
+    except InvalidOAuthTokenError as ite:
+        logger.info("Caught an invalid token error from the SDK: %s", str(ite))
+        raise InvalidTokenError(str(ite))
 
-    if request.GET.get('published'):
-        if request.GET.get('published') == 'true' or request.GET.get('published') == 'false':
-            published = request.GET.get('published')
-
-    if request.GET.get('page_link'):
-        api_response = client.get(rc, request.GET.get('page_link'))
-    else:
-
-        logger.debug('searching for "%s" and term "%s"' % (search_term, term_id))
-        api_response = accounts.list_active_courses_in_account(rc, account_id, search_term=search_term, enrollment_term_id=term_id, published=published, per_page=12)
-    
     logger.debug(api_response.text)
     account_courses = api_response.json()
     page_links = api_response.links
@@ -183,17 +93,17 @@ def main(request):
 
     canvas_hostname = request.session['LTI_LAUNCH'].get('custom_canvas_api_domain')
 
-    return render(request, 'account_courses/main.html', {'request': request, 
-        'account_courses': account_courses, 
-        'page_links': page_links, 
-        'search_term': request.GET.get('search_term',''), 
-        'terms': TERMS, 
-        'term_id': term_id, 
-        'published': published, 
+    return render(request, 'account_courses/main.html', {
+        'request': request,
+        'account_courses': account_courses,
+        'page_links': page_links,
+        'search_term': request.GET.get('search_term', ''),
+        'terms': TERMS,
+        'term_id': term_id,
+        'published': published,
         'self_link': self_link,
-        'canvas_hostname': canvas_hostname, })
-
-
+        'canvas_hostname': canvas_hostname,
+    })
 
 
 @require_http_methods(['GET'])
@@ -217,8 +127,6 @@ def tool_config(request):
         # optionally, supply a different URL for the link:
         # 'url': 'http://library.harvard.edu',
         'text': 'Courses in this account',
-        #'default': 'disabled',
-        #'visibility': 'public',
     }
     lti_tool_config.set_ext_param('canvas.instructure.com', 'account_navigation', account_nav_params)
     lti_tool_config.set_ext_param('canvas.instructure.com', 'privacy_level', 'public')

--- a/report_tools/requirements/base.txt
+++ b/report_tools/requirements/base.txt
@@ -11,3 +11,4 @@ git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.9#egg=canvas-python-s
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.10.20#egg=django-icommons-common==1.10.20
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.8#egg=django-icommons-ui==0.9.8
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.4#egg=django-auth-lti==1.2.4
+git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-oauth.git@v0.2#egg=django-canvas-oauth==0.2

--- a/report_tools/requirements/local.txt
+++ b/report_tools/requirements/local.txt
@@ -1,6 +1,8 @@
 #includes the base.txt requirements needed in all environments
 -r base.txt
 
+-e ../django-canvas-oauth
+
 # below are requirements specific to the local environment
 django-debug-toolbar==1.4
 django-sslserver==0.18

--- a/report_tools/requirements/local.txt
+++ b/report_tools/requirements/local.txt
@@ -1,8 +1,6 @@
 #includes the base.txt requirements needed in all environments
 -r base.txt
 
--e ../django-canvas-oauth
-
 # below are requirements specific to the local environment
 django-debug-toolbar==1.4
 django-sslserver==0.18

--- a/report_tools/settings/base.py
+++ b/report_tools/settings/base.py
@@ -9,7 +9,10 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 
 import os
 import logging
+from datetime import timedelta
+
 from django.core.urlresolvers import reverse_lazy
+
 from .secure import SECURE_SETTINGS
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -29,7 +32,7 @@ INSTALLED_APPS = [
     'django_auth_lti',
     'icommons_ui',
     'account_courses',
-    'canvas_oauth.apps.CanvasOauthConfig',
+    'canvas_oauth.apps.CanvasOAuthConfig',
 ]
 
 MIDDLEWARE_CLASSES = [
@@ -227,4 +230,5 @@ LOGGING = {
 
 CANVAS_OAUTH_CLIENT_ID = SECURE_SETTINGS['canvas_client_id']
 CANVAS_OAUTH_CLIENT_SECRET = SECURE_SETTINGS['canvas_client_secret']
-CANVAS_OAUTH_CANVAS_FQDN = SECURE_SETTINGS['canvas_fqdn']
+CANVAS_OAUTH_CANVAS_DOMAIN = SECURE_SETTINGS['canvas_domain']
+CANVAS_OAUTH_TOKEN_EXPIRATION_BUFFER = timedelta(minutes=3)

--- a/report_tools/settings/base.py
+++ b/report_tools/settings/base.py
@@ -28,8 +28,8 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django_auth_lti',
     'icommons_ui',
-    'icommons_common',
     'account_courses',
+    'canvas_oauth.apps.CanvasOauthConfig',
 ]
 
 MIDDLEWARE_CLASSES = [
@@ -42,6 +42,7 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.messages.middleware.MessageMiddleware',
     #  'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django_auth_lti.middleware.LTIAuthMiddleware',
+    'canvas_oauth.middleware.OAuthMiddleware',
 ]
 
 ROOT_URLCONF = 'report_tools.urls'
@@ -92,22 +93,8 @@ DATABASES = {
         'PASSWORD': SECURE_SETTINGS.get('db_default_password'),
         'HOST': SECURE_SETTINGS.get('db_default_host', '127.0.0.1'),
         'PORT': SECURE_SETTINGS.get('db_default_port', 5432),  # Default postgres port
-    },
-    'termtool': {
-        'ENGINE': 'django.db.backends.oracle',
-        'NAME': SECURE_SETTINGS.get('db_termtool_name'),
-        'USER': SECURE_SETTINGS.get('db_termtool_user'),
-        'PASSWORD': SECURE_SETTINGS.get('db_termtool_password'),
-        'HOST': SECURE_SETTINGS.get('db_termtool_host'),
-        'PORT': str(SECURE_SETTINGS.get('db_termtool_port')),
-        'OPTIONS': {
-            'threaded': True,
-        },
-        'CONN_MAX_AGE': 0,
     }
 }
-
-DATABASE_ROUTERS = ['icommons_common.routers.CourseSchemaDatabaseRouter']
 
 # Cache
 # https://docs.djangoproject.com/en/1.9/ref/settings/#std:setting-CACHES
@@ -221,6 +208,16 @@ LOGGING = {
             'handlers': ['default'],
             'propagate': False,
         },
+        'canvas_sdk': {
+            'level': _DEFAULT_LOG_LEVEL,
+            'handlers': ['default'],
+            'propagate': False,
+        },
+        'canvas_oauth': {
+            'level': _DEFAULT_LOG_LEVEL,
+            'handlers': ['default'],
+            'propagate': False,
+        },
         # Make sure that propagate is False so that the root logger doesn't get
         # involved after an app logger handles a log message.
     },
@@ -228,7 +225,6 @@ LOGGING = {
 
 # Other project specific settings
 
-REPORT_TOOLS = {
-    'canvas_client_id': SECURE_SETTINGS['canvas_client_id'],
-    'canvas_client_secret': SECURE_SETTINGS['canvas_client_secret'],
-}
+CANVAS_OAUTH_CLIENT_ID = SECURE_SETTINGS['canvas_client_id']
+CANVAS_OAUTH_CLIENT_SECRET = SECURE_SETTINGS['canvas_client_secret']
+CANVAS_OAUTH_CANVAS_FQDN = SECURE_SETTINGS['canvas_fqdn']

--- a/report_tools/urls.py
+++ b/report_tools/urls.py
@@ -16,11 +16,9 @@ from django.conf.urls import include, url
 
 from icommons_ui import views as ui_views
 
-from account_courses import views as ac_views
-
 urlpatterns = [
     url(r'^account_courses/', include('account_courses.urls', 'ac')),
     url(r'^auth_error/', ui_views.not_authorized, name='lti_auth_error'),
     url(r'^not_authorized/', ui_views.not_authorized, name='not_authorized'),
-    url(r'^oauth/complete', ac_views.oauth_complete, name='oauth_complete'),
+    url(r'^oauth/', include('canvas_oauth.urls')),
 ]


### PR DESCRIPTION
Use the `django-canvas-oauth` library to handle the OAuth2 flow for the app.  This not only allows for the handling of expired tokens (which is a feature missing from this application), but it also means that we no longer need the icommons_common library anymore since the reusable oauth library stores the token model.  Set a token expiration buffer of 3 minutes.

@cmurtaugh 